### PR TITLE
LJADIRD-40473: Ensure ignored prefixes end with _ when checking their presence

### DIFF
--- a/adi_env_parser/_parsers.py
+++ b/adi_env_parser/_parsers.py
@@ -128,7 +128,8 @@ class EnvironmentParser:
         """
         def variable_in_ignore_list(variable, ignore_list):
             for prefix in ignore_list:
-                if variable.startswith(prefix):
+                pfx = prefix + "_"
+                if variable.startswith(pfx):
                     return True
             return False
 

--- a/adi_env_parser/tests/parser_test.py
+++ b/adi_env_parser/tests/parser_test.py
@@ -181,6 +181,9 @@ class TestParser:
             "employee": {
                 "surname": "Smith"
             },
+            "externaluser": {
+                "surname": "Threepwood"
+            },
             "work_task_one": "done"
         }
 
@@ -188,6 +191,7 @@ class TestParser:
         env["IGNORE_employee__surname"] = "Smith"
         env["IGNORE_external__surname"] = "Doe"
         env["IGNORE_external__name"] = "John"
+        env["IGNORE_externaluser__surname"] = "Threepwood"
         env["IGNORE_visitor_surname"] = "Manley"
         env["IGNORE_visitor_name"] = "Les"
         env["IGNORE_work_task_one"] = "done"


### PR DESCRIPTION
Ignore prefixes must end with _ when checking if they exist
Updated tests