### PR TITLE
Fix exact prefix matching for ignored prefixes

### DIFF
--- a/adi_env_parser/_parsers.py
+++ b/adi_env_parser/_parsers.py
@@ -131,6 +131,8 @@ class EnvironmentParser:
                 pfx = prefix + "_"
                 if variable.startswith(pfx):
                     return True
+                if variable == prefix:
+                    return True
             return False
 
         extracted = {}

--- a/adi_env_parser/tests/parser_test.py
+++ b/adi_env_parser/tests/parser_test.py
@@ -175,7 +175,8 @@ class TestParser:
 
     def test_exclusion_list(self):
         env_prefix = "IGNORE"
-        ignore_prefixes = ["IGNORE_external", "IGNORE_visitor"]
+        ignore_prefixes = ["IGNORE_external", "IGNORE_visitor",
+                           "IGNORE_exact_match"]
 
         expected = {
             "employee": {
@@ -194,6 +195,7 @@ class TestParser:
         env["IGNORE_externaluser__surname"] = "Threepwood"
         env["IGNORE_visitor_surname"] = "Manley"
         env["IGNORE_visitor_name"] = "Les"
+        env["IGNORE_exact_match"] = "true"
         env["IGNORE_work_task_one"] = "done"
 
         parser = EnvironmentParser(env_prefix,


### PR DESCRIPTION
Environment variables with names exactly matching one of ignored prefixes were not ignored.

- Add additional condition to check for exact match
- Update tests to verify fix